### PR TITLE
Update to libtorrent 2.0.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apk update && \
     make 
 
 
-FROM emmercm/libtorrent:2.0.5-alpine
+FROM emmercm/libtorrent:2.0.6-alpine
 
 LABEL name="docker-deluge" \
       maintainer="Jee jee@eer.fr" \


### PR DESCRIPTION
Dependent image was updated April 19. Minor point update with some important fixes.