### PR TITLE
fix(twisted): apply patch from deluge PR 399

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,8 +59,11 @@ RUN apk update && \
         python3-dev && \
     install -v -m755 /tmp/unrar /usr/local/bin && \
     python3 -m ensurepip --upgrade && \
+		# QuickFIx https://github.com/deluge-torrent/deluge/pull/399 (twisted 22.10 breaking change - web ui base path)
+		wget https://patch-diff.githubusercontent.com/raw/deluge-torrent/deluge/pull/399.patch -O /tmp/deluge.patch && \
     git clone git://deluge-torrent.org/deluge.git /tmp/deluge && \
     cd /tmp/deluge && \
+		git apply /tmp/deluge.patch && \
     pip3 --timeout 40 --retries 10  install --no-cache-dir --upgrade  \
         wheel \
         pip \


### PR DESCRIPTION
breaking change for twisted 22.10 

```
Traceback (most recent call last):

  File "/usr/bin/deluge-web", line 33, in <module>

    sys.exit(load_entry_point('deluge==2.1.1.dev6', 'gui_scripts', 'deluge-web')())

  File "/usr/lib/python3.10/site-packages/deluge-2.1.1.dev6-py3.10.egg/deluge/ui/web/__init__.py", line 6, in start

    web.start()

  File "/usr/lib/python3.10/site-packages/deluge-2.1.1.dev6-py3.10.egg/deluge/ui/web/web.py", line 71, in start

    self.__server = server.DelugeWeb(options=self.options)

  File "/usr/lib/python3.10/site-packages/deluge-2.1.1.dev6-py3.10.egg/deluge/ui/web/server.py", line 685, in __init__

    self.top_level.putChild(self.base.strip('/'), self.top_level)

  File "/usr/lib/python3.10/site-packages/twisted/web/resource.py", line 234, in putChild

    raise TypeError(f"Path segment must be bytes, but {path!r} is {type(path)}")

TypeError: Path segment must be bytes, but 'deluge_stuff' is <class 'str'>
```

Temporary solution: 

apply this patch https://github.com/deluge-torrent/deluge/pull/399 thank's to @DjLegolas 